### PR TITLE
Fix data-sly-call attribute value definition

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1296,7 +1296,7 @@ Template blocks can be used like function calls: in their declaration they can g
 * Calls a declared HTML block, passing parameters to it.
 * **Element:** always shown.
 * **Content of element:** replaced with the content of the called `data-sly-template` element.
-* **Attribute value:** optional; an expression defining the template identifier and the parameters to pass.
+* **Attribute value:** required; an expression defining the template identifier and the parameters to pass.
 * **Attribute identifier:** none.
 
 ##### 2.2.10.3. Examples


### PR DESCRIPTION
The `data-sly-call` specification states that attribute value is optional.
I think it is wrong, because calling nothing doesn't make sense. I checked Sightly and it throws:
```
org.apache.sling.scripting.sightly.java.compiler.SightlyJavaCompilerException: data-sly-call: String &apos;&apos; does not represent a HTL template.
```