### PR TITLE
Fix dead link to HTL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 HTML Template Language Specification
 ====
-The [HTML Template Language](https://docs.adobe.com/docs/en/htl.html "Introduction to the HTML Template Language") (HTL), formerly known as Sightly, has been introduced with [Adobe Experience Manager](http://www.adobe.com/solutions/web-experience-management.html) 6.0 and takes the place of JSP (JavaServer Pages) as the preferred and recommended server-side template system for HTML.
+The [HTML Template Language](https://experienceleague.adobe.com/docs/experience-manager-htl/content/overview.html "HTL Guide") (HTL), formerly known as Sightly, has been introduced with [Adobe Experience Manager](http://www.adobe.com/solutions/web-experience-management.html) 6.0 and takes the place of JSP (JavaServer Pages) as the preferred and recommended server-side template system for HTML.
 
 This is the [HTL Specification](https://github.com/adobe/htl-spec/blob/master/SPECIFICATION.md) that defines the syntax and the behavior of the language.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The link pointed to the general docs page instead of the HTL Guide.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
