### PR TITLE
Fix tiny typo

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1078,7 +1078,7 @@ The element name is automatically XSS-protected with the `elementName` context, 
 * Keeps or removes the element depending on the attribute value.
 * **Element:** shown if test evaluates to `true`.
 * **Content of element:** shown if test evaluates to `true`.
-* **Attribute value:** optional; evaluated as `Boolean` (but not type-cased to `Boolean` when exposed in a variable); evaluates to `false` if the value is omitted.
+* **Attribute value:** optional; evaluated as `Boolean` (but not type-casted to `Boolean` when exposed in a variable); evaluates to `false` if the value is omitted.
 * **Attribute identifier:** optional; identifier name to access the result of the test.
 * **Scope:** The identifier set by the `data-sly-test` block element is global to the script and can be used anywhere after its declaration:
 


### PR DESCRIPTION
Data-sly-test stores the original value on the optional attribute AS-IS (no type-casting) involved.

## Description

This fixes a small typo in the documentation. "type-cased" was written instead of "type-casted"

## Related Issue

??

## Motivation and Context

Type casing seems to indicate that the casing of a string would be preserved, in reality, the type is preserved.

## How Has This Been Tested?

NA

## Screenshots (if appropriate):

## Types of changes

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
