### PR TITLE
Deprecate JavaScript Use API for AEMaaCS

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1443,6 +1443,11 @@ The Use-API POJOs can also expose a public method, called `init`, with the follo
 The `bindings` map can contain objects that provide context to the currently executed HTL script that the Use-API object can use for its processing.
 
 ### 4.2. JavaScript Use-API
+
+>The JavaScript Use API has been deprecated for use with AEM as a Cloud Service. Please use [the Java Use API instead.](https://experienceleague.adobe.com/en/docs/experience-manager-htl/content/java-use-ap)
+>
+>[Please see the AEM as a Cloud Service release notes](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/deprecated-removed-features) for more information on deprecated and removed features.
+
 Use objects can also be defined with JavaScript, using the following conventions:
 
 ```javascript

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1444,7 +1444,7 @@ The `bindings` map can contain objects that provide context to the currently exe
 
 ### 4.2. JavaScript Use-API
 
->The JavaScript Use API has been deprecated for use with AEM as a Cloud Service. Please use [the Java Use API instead.](https://experienceleague.adobe.com/en/docs/experience-manager-htl/content/java-use-ap)
+>The JavaScript Use API has been deprecated for use with AEM as a Cloud Service. Please use [the Java Use API instead.](https://experienceleague.adobe.com/en/docs/experience-manager-htl/content/java-use-api)
 >
 >[Please see the AEM as a Cloud Service release notes](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/deprecated-removed-features) for more information on deprecated and removed features.
 


### PR DESCRIPTION
CQDOC-22049

## Description

Deprecate JavaScript Use API for AEMaaCS. See CQDOC-22049 for details.

## Related Issue

See CQDOC-22049 for details.

## Motivation and Context

The JavaScript Use API is officially deprecated for use with AEM as a Cloud Service due to challenges users have debugging and maintaining code that leverages the API, as well as performance limitations compared to the Java alternative.

## How Has This Been Tested?

Doc-only change

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
